### PR TITLE
Enable cpp20

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,9 +34,9 @@ test --test_tag_filters=-integration_tests
 
 ####### compiler and linker options ######
 
-# enable c++17
-build --cxxopt=-std=c++17
-build --host_cxxopt=-std=c++17
+# enable c++20
+build --cxxopt=-std=c++2a
+build --host_cxxopt=-std=c++2a
 
 build --conlyopt=-std=c99
 build --host_conlyopt=-std=c99

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,12 +19,12 @@ jobs:
 
     - name: bazel-build
       env:
-        CC: gcc-9
-        CXX: g++-9
+        CC: gcc-10
+        CXX: g++-10
       run: bazel build //...
 
     - name: bazel-test
       env:
-        CC: gcc-9
-        CXX: g++-9
+        CC: gcc-10
+        CXX: g++-10
       run: bazel test --test_output=all //...

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,20 +3,25 @@ workspace(name = "rcbe_engine")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-skylib_version = "0.7.0"
+skylib_version = "1.0.3"
 
 http_archive(
     name = "bazel_skylib",
-    sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
-    type = "tar.gz",
-    url = "https://github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib.{}.tar.gz".format(skylib_version, skylib_version),
+    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+    urls = [
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(skylib_version, skylib_version),
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(skylib_version, skylib_version),
+    ],
 )
 
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 # External deps
 
 git_repository(
     name = "com_github_nelhage_rules_boost",
-    commit = "6d6fd834281cb8f8e758dd9ad76df86304bf1869",
+    commit = "fbac9be7640ecc0fab075233d394f08f1a37e449",
     remote = "https://github.com/nelhage/rules_boost",
 )
 

--- a/gl_extensions/include/core/gl_helpers.hpp
+++ b/gl_extensions/include/core/gl_helpers.hpp
@@ -2,7 +2,7 @@
 #define RCBE_ENGINE_GL_HELPERS_HPP
 
 #include <cstdint>
-#include <array.hpp>
+#include <array>
 
 #include <GL/gl.h>
 

--- a/input_manager/include/core/EditorInputManager.hpp
+++ b/input_manager/include/core/EditorInputManager.hpp
@@ -2,7 +2,6 @@
 #define RCBE_ENGINE_EDITORINPUTMANAGER_HPP
 
 #include <memory>
-#include <enable_shared_from_this.hpp>
 
 #include <core/InputManagerImplementation.hpp>
 

--- a/renderer/src/main.cpp
+++ b/renderer/src/main.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <chrono>
 #include <memory>
+#include <span> // left to clarify that c++20 is used
 
 #include <common/utils/output_utils.hpp>
 #include <core/AbstractInputManager.hpp>
@@ -85,6 +86,11 @@ int main(int argc, char * argv[]) {
         BOOST_LOG_TRIVIAL(error) << "Exception thrown: " << e.what();
         return 1;
     }
+
+#ifdef  RCBE_DEBUG
+    std::array<int, 2> arr = {0, 1};
+    std::span s{arr};
+#endif
 
     return 0;
 }


### PR DESCRIPTION
Incremented skylib version to 1.0.3. Boost update to 1.74. C++20 is enabled and can be started to be used.