### PR TITLE
[2wu9800] Make CoreObject use type_index, as component index

### DIFF
--- a/common/include/common/fundamentals/types.hpp
+++ b/common/include/common/fundamentals/types.hpp
@@ -3,8 +3,7 @@
 
 #include <filesystem>
 
-namespace rcbe::core
-{
+namespace rcbe::core {
 using EngineScalar = double;
 using EngineIntergral = int;
 // TODO: rename to EngineFsPath, consider moving to a separate header.

--- a/datamodel/include/datamodel/core/Dimensions.hpp
+++ b/datamodel/include/datamodel/core/Dimensions.hpp
@@ -1,22 +1,33 @@
 #ifndef RCBE_ENGINE_DIMENSIONS_HPP
 #define RCBE_ENGINE_DIMENSIONS_HPP
 
+#include <type_traits>
+
 #include <rcbe-engine/fundamentals/types.hpp>
 
 #include <nlohmann/json_fwd.hpp>
 
 namespace rcbe::core {
 
-template <typename Value = core::EngineIntergral>
+template <typename Value = EngineIntergral>
 struct dimensions_impl {
     using ValueType = Value;
 
     ValueType width;
     ValueType height;
+
+    /// TODO: consider making typelist helper to specify a list of types that can be used with this template
+    /// I mean dimension_impl @sckorn
+    template <typename T, typename = std::enable_if_t<
+            std::is_convertible_v<T, EngineScalar> || std::is_convertible_v<T, EngineIntergral>, void>>
+    [[nodiscard]] dimensions_impl<std::remove_cvref_t<T>> convertUnerlying() const {
+        using NonQualT = std::remove_cvref_t<T>;
+        return dimensions_impl<NonQualT>{static_cast<NonQualT>(width), static_cast<NonQualT>(height)};
+    }
 };
 
-using Dimensions = dimensions_impl<core::EngineIntergral>;
-using ScalarDimensions = dimensions_impl<core::EngineScalar>;
+using Dimensions = dimensions_impl<EngineIntergral>;
+using ScalarDimensions = dimensions_impl<EngineScalar>;
 
 }
 

--- a/datamodel/test/core_tests.cpp
+++ b/datamodel/test/core_tests.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+
+#include <rcbe-engine/datamodel/core/CoreObject.hpp>
+#include <rcbe-engine/datamodel/core/Dimensions.hpp>
+
+class DimensionsTests : public ::testing::Test {
+public:
+
+    [[nodiscard]] rcbe::core::Dimensions getTestDimensions() const {
+        return dim;
+    }
+
+    [[nodiscard]] constexpr rcbe::core::EngineIntergral initialWidth() const {
+        return IWIDTH;
+    }
+
+    [[nodiscard]] constexpr rcbe::core::EngineIntergral initialHeight() const {
+        return IHEIGHT;
+    }
+
+private:
+    static constexpr rcbe::core::EngineIntergral IWIDTH = 1024;
+    static constexpr rcbe::core::EngineIntergral IHEIGHT = 768;
+    static constexpr rcbe::core::Dimensions dim{IWIDTH, IHEIGHT};
+};
+
+using CoreObjectTests = DimensionsTests;
+
+namespace {
+struct some_empty_struct {};
+}
+
+TEST_F(DimensionsTests, IntegerDimensions) {
+    const auto dim = getTestDimensions();
+
+    ASSERT_EQ(dim.width, initialWidth());
+    ASSERT_EQ(dim.height, initialHeight());
+}
+
+TEST_F(DimensionsTests, DoubleDimensions) {
+    using ScalarT = rcbe::core::ScalarDimensions::ValueType;
+    const auto sdim = getTestDimensions().convertUnerlying<ScalarT>();
+
+    ASSERT_EQ(sdim.width, static_cast<ScalarT>(initialWidth()));
+    ASSERT_EQ(sdim.height, static_cast<ScalarT>(initialHeight()));
+}
+
+TEST_F(CoreObjectTests, Components) {
+    using DimT = rcbe::core::Dimensions;
+
+    rcbe::core::CoreObject co{some_empty_struct{}};
+
+    auto dim = getTestDimensions();
+    co.addComponent(std::move(dim));
+
+    ASSERT_TRUE(co.hasComponent<DimT>());
+    const auto dim_comp_ptr = co.getComponent<DimT>();
+    ASSERT_NE(dim_comp_ptr, nullptr);
+    
+    const auto &dim_comp = dim_comp_ptr->as<DimT>();
+    ASSERT_EQ(dim_comp.width, initialWidth());
+    ASSERT_EQ(dim_comp.height, initialHeight());
+}
+
+TEST_F(CoreObjectTests, Tags) {
+    static constexpr const char * TAG = "systag";
+    rcbe::core::CoreObject co{some_empty_struct{}};
+
+    ASSERT_TRUE(co.addSystemTag(std::string(TAG)));
+    ASSERT_TRUE(co.hasSystemTag(std::string(TAG)));
+}

--- a/renderer/src/main.cpp
+++ b/renderer/src/main.cpp
@@ -107,8 +107,8 @@ int main(int argc, char * argv[]) {
 
             auto material_copy = material;
 
-            first_corner_wall.addComponent("mesh", std::move(meshes[0]));
-            first_corner_wall.addComponent("material", std::move(material_copy));
+            first_corner_wall.addComponent<rcbe::geometry::Mesh>(std::move(meshes[0]));
+            first_corner_wall.addComponent<rcbe::rendering::Material>(std::move(material_copy));
         }
 
         {
@@ -118,8 +118,8 @@ int main(int argc, char * argv[]) {
             second_mesh.transform(t);
 
             auto material_copy = material;
-            second_corner_wall.addComponent("mesh", std::move(second_mesh));
-            second_corner_wall.addComponent("material", std::move(material_copy));
+            second_corner_wall.addComponent<rcbe::geometry::Mesh>(std::move(second_mesh));
+            second_corner_wall.addComponent<rcbe::rendering::Material>(std::move(material_copy));
         }
 
         {
@@ -135,8 +135,8 @@ int main(int argc, char * argv[]) {
 
             rcbe::rendering::Material mat(std::move(shader_args_), {}, true);
 
-            wolf.addComponent("mesh", std::move(low_poly_wolf_mesh));
-            wolf.addComponent("material", std::move(mat));
+            wolf.addComponent<rcbe::geometry::Mesh>(std::move(low_poly_wolf_mesh));
+            wolf.addComponent<rcbe::rendering::Material>(std::move(mat));
         }
 
         auto camera_conf = rcbe::utils::read_from_file<rcbe::rendering::camera_config>(


### PR DESCRIPTION
`CoreObject` now stores its components mapped by their respective `type_index`.
This allows access via template methods with type of the component. Removes error prone usage of `std::string` tags.