### PR TITLE
[2znu2be] Pass offset to BinaryBuffer as reference

### DIFF
--- a/common/include/common/binary/BinaryBuffer.hpp
+++ b/common/include/common/binary/BinaryBuffer.hpp
@@ -63,7 +63,8 @@ public:
         return os;
     }
 
-    [[nodiscard]] BinaryBuffer at(size_t offset, size_t size = 0) const;
+    [[nodiscard]] BinaryBuffer at(size_t &&offset, size_t size = 0) const;
+    [[nodiscard]] BinaryBuffer at(size_t &offset, size_t size = 0) const;
 
     template <typename ReturnType>
     [[nodiscard]] ReturnType get() {
@@ -88,13 +89,14 @@ private:
     BinaryBuffer(ViewType::const_iterator begin, ViewType::const_iterator end);
 
     template <typename BinaryBufferContainer>
-    BinaryBuffer constructFromChunk(const BinaryBufferContainer &bbc, const size_t offset, const size_t size) const {
+    BinaryBuffer constructFromChunk(const BinaryBufferContainer &bbc, size_t &offset, const size_t size) const {
         if (bbc.empty())
             throw std::runtime_error("BinaryBuffer::at on empty buffer");
         auto it = bbc.begin();
         std::advance(it, offset);
         auto eit = it;
         std::advance(eit, size);
+        offset += size;
         return rcbe::binary::BinaryBuffer(it, eit);
     }
 

--- a/common/src/binary/BinaryBuffer.cpp
+++ b/common/src/binary/BinaryBuffer.cpp
@@ -55,7 +55,14 @@ BinaryBuffer &BinaryBuffer::append(BinaryBuffer &&bb) {
     return appendImplementation(bb);
 }
 
-BinaryBuffer BinaryBuffer::at(size_t offset, size_t size) const {
+BinaryBuffer BinaryBuffer::at(size_t &&offset, size_t size) const {
+    if (view_)
+        return constructFromChunk(buffer_view_, offset, size);
+    else
+        return constructFromChunk(buffer_, offset, size);
+}
+
+BinaryBuffer BinaryBuffer::at(size_t &offset, size_t size) const {
     if (view_)
         return constructFromChunk(buffer_view_, offset, size);
     else

--- a/datamodel/src/geometry/BinaryStlFile.cpp
+++ b/datamodel/src/geometry/BinaryStlFile.cpp
@@ -12,14 +12,10 @@ void to_binary(BinaryBuffer &b, const rcbe::geometry::binary_stl_header &bsh) {
 
 void from_binary(const BinaryBuffer &b, rcbe::geometry::binary_stl_chunk &bsc) {
     size_t offset = 0;
-    bsc.normal = b.at(0, sizeof(float) * 3).get<rcbe::math::Vector3f>();
-    offset += sizeof(float) * 3;
+    bsc.normal = b.at(offset, sizeof(float) * 3).get<rcbe::math::Vector3f>();
     bsc.v1 = b.at(offset, sizeof(float) * 3).get<rcbe::math::Vector3f>();
-    offset += sizeof(float) * 3;
     bsc.v2 = b.at(offset, sizeof(float) * 3).get<rcbe::math::Vector3f>();
-    offset += sizeof(float) * 3;
     bsc.v3 = b.at(offset, sizeof(float) * 3).get<rcbe::math::Vector3f>();
-    offset += sizeof(float) * 3;
     bsc.extra_bytes_count = b.at(offset, sizeof(uint16_t)).get<uint16_t>();
 }
 

--- a/datamodel/src/visual/TGATexture.cpp
+++ b/datamodel/src/visual/TGATexture.cpp
@@ -105,19 +105,14 @@ void TextureImplementation::parseV2(rcbe::binary::BinaryBuffer &&bb) {
 void TextureImplementation::parseV1(rcbe::binary::BinaryBuffer &&bb) {
     size_t offset = 0;
     const auto id_length = bb.at(offset, sizeof(uint8_t)).get<uint8_t>();
-    offset += sizeof(uint8_t);
 
     const auto color_map_type = bb.at(offset, sizeof(uint8_t)).get<uint8_t>();
-    offset += sizeof(uint8_t);
 
     const auto image_type = bb.at(offset, sizeof(uint8_t)).get<uint8_t>();
-    offset += sizeof(uint8_t);
 
     color_map_spec_ = bb.at(offset, ColorMapSpecification::SIZE).get<ColorMapSpecification>();
-    offset += ColorMapSpecification::SIZE;
 
     image_spec_ = bb.at(offset, ImageSpecification::SIZE).get<ImageSpecification>();
-    offset += ImageSpecification::SIZE;
 
     image_body_ = ImageBodyType {image_spec_.height, image_spec_.width};
 
@@ -132,7 +127,6 @@ void TextureImplementation::parseV1(rcbe::binary::BinaryBuffer &&bb) {
 
             for (size_t j = 0; j < pixel_depth_bytes; ++j) {
                 color_comp_bytes[j] = bb.at(offset, sizeof(uint8_t)).get<uint8_t>();
-                offset += sizeof(uint8_t);
             }
 
             // TGA is RGB(A) by default, so if we need GBR(A), we need to reverse the order of bytes

--- a/datamodel/test/texture_tests.cpp
+++ b/datamodel/test/texture_tests.cpp
@@ -2,7 +2,7 @@
 
 #include <rcbe-engine/datamodel/visual/Texture.hpp>
 
-TEST(Textures, PNG) {
+TEST(Textures, TGA) {
     rcbe::visual::Texture tex {"external/brick_wall_texture/file/brick_wall_texture.tga", rcbe::visual::texture_config {}};
     const auto total_values = tex.getWidth() * tex.getHeight();
     ASSERT_EQ(total_values, tex.getImageBody().size());


### PR DESCRIPTION
In order to avoid a lot of redundant code, that is needed to update offset after each at call, we now pass offset as non-const reference. 